### PR TITLE
Change miktex install from a portable to a regular one

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -14,3 +14,25 @@ for %%f in ("%LIBRARY_PREFIX%\miktex\miktex\bin\*.exe") do (
 )
 if errorlevel 1 exit 1
 
+rem DO NOT INSTALL PACKAGES AS ADMIN: it adds a lot of cache files which have
+rem the path hardcoded to the current locations, so let that happen in the user
+rem install and on the users machine:
+
+rem Change the install variant to a regular one, so that latex packages
+rem installed by the user go into the users home directory...
+(
+echo ;;; MiKTeX startup information
+echo.
+echo ;;; The effect of this file is that the main install location in the conda env
+echo ;;; is not touched by the latex package installer and all packages are installed
+echo ;;; into a location under USERPROFILE.
+echo.
+echo [Auto]
+echo Config=Regular
+echo.
+echo [PATHS]
+echo CommonInstall=..\..
+echo CommonData=..\..
+echo CommonConfig=..\..
+) > "%PREFIX%\Library\miktex\miktex\config\miktexstartup.ini"
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: True  # [not win]
-  number: 0
+  number: 1
   binary_relocation: false
 
 requirements:


### PR DESCRIPTION
The portable install has the problem that additional packages and things like
caches are placed in the install location. Condas way of linking files into the
environments (even the root env) means that information is shared between envs
and installs (e.g. the latex package DB is shared, but not the packages itself;
also the package DB is reset on update but the package files itself are kept).

To avoid this, the miktex install is changed from "Portable" to "Regular" and
the paths are manually set so that the "common" data/config paths still point to
the miktex install in the conda env, but user installed/changed data now ends up
in the user profile path:

```
λ initexmf --report
MiKTeX: 2.9
Invokers: ConEmu/ConEmuC64/cmd
SystemAdmin: no
PowerUser: no
OS: Windows 7 Professional, 64-bit, Service Pack 1, build 7601
Root 0: C:\Users\jschulz\AppData\Roaming\MiKTeX\2.9
Root 1: C:\Users\jschulz\AppData\Local\MiKTeX\2.9
Root 2: C:\portabel\miniconda\Library\miktex
UserInstall: C:\Users\jschulz\AppData\Roaming\MiKTeX\2.9
UserData: C:\Users\jschulz\AppData\Local\MiKTeX\2.9
UserConfig: C:\Users\jschulz\AppData\Roaming\MiKTeX\2.9
CommonInstall: C:\portabel\miniconda\Library\miktex
CommonData: C:\portabel\miniconda\Library\miktex
CommonConfig: C:\portabel\miniconda\Library\miktex
```

No packages are added to the default install as that would also add cache files
and so on which include hardcoded paths. Until that is understood, lets just let
the user download all the packages in the post-link.bat...

Closes: https://github.com/conda-forge/miktex-feedstock/issues/1
