### PR TITLE
Include a binary wrapper for the *latex binaries

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,18 +1,33 @@
 
 
-7za x miktex-portable-%PKG_VERSION%.exe -o%LIBRARY_PREFIX%\miktex
+7za x miktex-portable-%PKG_VERSION%.exe -o%LIBRARY_PREFIX%\miktex >NUL
 if errorlevel 1 exit 1
-
 
 rem SCRIPTS dir should already be created by 7za install
 mkdir "%SCRIPTS%"
 if errorlevel 1 exit 1
 
-rem latex tools must be run from miktex tree
+rem latex tools must be run from miktex tree - add batch file for everything
 for %%f in ("%LIBRARY_PREFIX%\miktex\miktex\bin\*.exe") do (
 	echo @%%~dp0\..\Library\miktex\miktex\bin\%%~nf %%* >> "%SCRIPTS%\%%~nf.bat"
 )
 if errorlevel 1 exit 1
+
+rem build the wrapper: pandoc expects commands like pdflatex to be exe files,
+rem batch files do not work :-/
+
+rem assumes that go is in path, which seems to be true on appveyor
+set GOPATH=c:\gopath
+go get "github.com/kardianos/osext"
+go build -ldflags="-s -w" "%RECIPE_DIR%\wrapper.go"
+if errorlevel 1 exit 1
+
+rem add exe versions for the most important commands--which pandoc tries to
+rem run, as the wrapper.exe is big ...
+for /F %%f in ("pdflatex lualatex xelatex") do copy "wrapper.exe" "%SCRIPTS%\%%f.exe"
+if errorlevel 1 exit 1
+
+del wrapper.exe
 
 rem DO NOT INSTALL PACKAGES AS ADMIN: it adds a lot of cache files which have
 rem the path hardcoded to the current locations, so let that happen in the user

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: True  # [not win]
-  number: 1
+  number: 2
   binary_relocation: false
 
 requirements:
@@ -20,7 +20,8 @@ requirements:
 
 test:
   commands:
-    - pdflatex --help
+    - pdflatex.bat --help
+    - pdflatex.exe --help
     - mpm --help
 
 about:

--- a/recipe/wrapper.go
+++ b/recipe/wrapper.go
@@ -1,0 +1,23 @@
+package main
+
+//import "fmt"
+import "os"
+import "os/exec"
+import "path/filepath"
+import "github.com/kardianos/osext"
+
+
+func main() {
+  exec_name, _ := osext.Executable()
+  dir, file := filepath.Split(exec_name)
+  new_exec_name := filepath.Clean(filepath.Join(dir, "..", "Library", "miktex", "miktex", "bin", file))
+  cmd := exec.Command(new_exec_name, os.Args[1:]...)
+  cmd.Stdin = os.Stdin
+  cmd.Stdout = os.Stdout
+  cmd.Stderr = os.Stderr
+  err := cmd.Run()
+  if err != nil {
+//        fmt.Fprintf(os.Stderr, "%v\n", err)
+        os.Exit(1)
+    }
+}


### PR DESCRIPTION
pandoc does not like it when the *latex packages are batch files instead of exe files. So include a binary wrapper which does the same as the batch files.

Unfortunately, the wrapper is quite big because I was only able to build it in go :-) So only use it for the *latex binaries, not as a complete replacement for the batch files...
