### PR TITLE
leave-maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,5 +39,4 @@ about:
 extra:
   recipe-maintainers:
     - ivoflipse
-    - Korijn
     - jankatins


### PR DESCRIPTION
I no longer wish to maintain conda packages, so I'm editing myself out of the maintainers in the recipes.